### PR TITLE
Journey posts: securing the server, Compose migration, updates, whole-stack consolidation, and Plex-into-Docker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ I'm documenting my journey of setting up a home server capable of running AI wor
 - [Locking Down the Server: SSH, Firewall, and Secrets](posts/2026-07-10-securing-the-server/README.md) - A security audit covering SSH hardening, a router-reserved IP, a UFW firewall, and fixing an empty Open WebUI secret key
 - [Consolidating the AI Stack with Docker Compose](posts/2026-07-10-docker-compose-migration/README.md) - Migrating Ollama and Open WebUI from a native service and a hand-run container into one declarative Compose stack
 - [Automating OS Updates (and What I Chose NOT to Automate)](posts/2026-07-10-automating-updates/README.md) - Setting up unattended-upgrades for security patches while deliberately holding the GPU stack and container updates
+- [Bringing the Whole Stack Under One Roof: Dependabot, CI, and Containerizing Plex](posts/2026-07-10-whole-stack-in-git/README.md) - Pinning the last hand-run containers, folding Home Assistant and Wyoming into the Compose stack, a conservative Dependabot auto-merge policy, and staging Plex's containerization behind a profile gate
+- [Plex Joins the Stack: Containerizing a 1 TB Library Without Losing It](posts/2026-07-10-plex-into-docker/README.md) - Migrating Plex from a native `.deb` into the Compose stack — binding the media at its original paths, discovering the LSIO config layout with an empty-init, and removing the native package without a `purge` that would have deleted the library
 
 ### Topics Covered
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ I'm documenting my journey of setting up a home server capable of running AI wor
 - [Welcome to My AI Home Server Journey](posts/2024-12-05-welcome/README.md) - Introduction to this project and what to expect
 - [Desktop Build Parts List](posts/2024-12-05-desktop-build/README.md) - The hardware components chosen for this build and why
 - [Installing Ollama and OpenWebUI](posts/2024-12-21-ollama-openwebui-setup/README.md) - Setting up local LLM inference with Ollama and a web interface
+- [Locking Down the Server: SSH, Firewall, and Secrets](posts/2026-07-10-securing-the-server/README.md) - A security audit covering SSH hardening, a router-reserved IP, a UFW firewall, and fixing an empty Open WebUI secret key
+- [Consolidating the AI Stack with Docker Compose](posts/2026-07-10-docker-compose-migration/README.md) - Migrating Ollama and Open WebUI from a native service and a hand-run container into one declarative Compose stack
+- [Automating OS Updates (and What I Chose NOT to Automate)](posts/2026-07-10-automating-updates/README.md) - Setting up unattended-upgrades for security patches while deliberately holding the GPU stack and container updates
 
 ### Topics Covered
 

--- a/posts/2026-07-10-automating-updates/README.md
+++ b/posts/2026-07-10-automating-updates/README.md
@@ -1,0 +1,63 @@
+# Automating OS Updates (and What I Chose NOT to Automate)
+
+**Date:** July 10, 2026  
+**Author:** Jacob Frericks  
+**Tags:** homelab, maintenance, security, updates
+
+---
+
+While going through the security audit, I noticed a backlog of pending `apt` security updates that had just been quietly piling up, with nothing in place to apply them automatically. For a box that's now family-facing, that's not a great place to be — I want security patches landing on their own, but not in a way that could surprise me with a broken service on a random Tuesday morning.
+
+## unattended-upgrades
+
+I installed and configured `unattended-upgrades` to automatically apply security updates:
+
+```bash
+sudo apt install unattended-upgrades
+sudo dpkg-reconfigure --priority=low unattended-upgrades
+```
+
+In `/etc/apt/apt.conf.d/50unattended-upgrades`, I confirmed the security repo was enabled, and in `/etc/apt/apt.conf.d/20auto-upgrades` I set it to run daily:
+
+```
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Unattended-Upgrade "1";
+```
+
+I also enabled an automatic reboot, but scheduled for 4:00 AM:
+
+```
+Unattended-Upgrade::Automatic-Reboot "true";
+Unattended-Upgrade::Automatic-Reboot-Time "04:00";
+```
+
+That way, if a kernel update needs a reboot to take effect, it happens while everyone's asleep instead of mid-Plex-movie or mid-homework-help-from-the-AI.
+
+> **Note:** I deliberately left `Automatic-Reboot-WithUsers` alone (default behavior applies) rather than forcing a reboot with active sessions — the 4 AM window makes that mostly moot anyway.
+
+## Holding the GPU Stack
+
+There's one category of package I explicitly did **not** want auto-updating: the NVIDIA driver and CUDA packages. Those are the single most likely thing to break local inference — a driver bump that's incompatible with the currently-running kernel, or a CUDA version mismatch with the Ollama container, would take down the whole AI stack with no warning. I pinned them:
+
+```bash
+sudo apt-mark hold nvidia-driver nvidia-kernel-dkms cuda-toolkit
+```
+
+Now `unattended-upgrades` (and a stray `apt upgrade`) will skip those packages entirely until I deliberately unhold and upgrade them myself, ideally right before I'm ready to test that everything still works.
+
+## What Stays Manual, and Why
+
+A few things are staying hands-on for now, on purpose:
+
+- **Container image updates.** The Ollama and Open WebUI images from the new compose stack aren't part of this automation. Auto-pulling a new tag on a family-facing service is too risky without a way to test and roll back first — that's waiting for the compose stack to live in git with a real CI/CD pipeline, which is a good topic for a future post.
+- **Model management.** Choosing, pulling, and pruning models is a deliberate decision each time (disk space and VRAM are both finite), not something to run on a timer.
+- **GPU driver upgrades.** Same reasoning as the hold above — when it's time to move to a new driver version, I want to do it consciously and verify inference still works afterward.
+- **External access.** Setting up the eventual WireGuard VPN for remote access is a manual, one-time project, not an "automate and forget" task.
+
+---
+
+The theme here is that automation is great for things with a well-understood, low-risk blast radius — security patches on a schedule the family won't notice — and a poor fit for anything where a bad update could quietly break AI inference or, worse, open up unexpected access. The container update story is the next piece of that puzzle, once there's a proper pipeline to make it safe.
+
+---
+
+[← Back to Home](../../README.md)

--- a/posts/2026-07-10-docker-compose-migration/README.md
+++ b/posts/2026-07-10-docker-compose-migration/README.md
@@ -1,0 +1,105 @@
+# Consolidating the AI Stack with Docker Compose
+
+**Date:** July 10, 2026  
+**Author:** Jacob Frericks  
+**Tags:** homelab, docker, ollama, openwebui, compose
+
+---
+
+Since the original setup post, Ollama had been running as a native systemd service directly on Debian, while Open WebUI was a hand-run `docker run` command I'd typed once and never touched again. Two completely different management styles for two halves of the same stack — one gets updated with `apt`/the install script, the other with a manual `docker pull` and re-run. That's exactly the kind of asymmetry that turns into a maintenance headache, so the goal was to fold both into a single, declarative `docker compose` stack.
+
+## NVIDIA Container Toolkit
+
+Getting Ollama into a container meant it needed GPU access from inside Docker, which doesn't work out of the box. The NVIDIA Container Toolkit is what bridges that gap — it exposes the host's GPU and drivers to containers so they can talk to the 3090 as if they were running natively.
+
+```bash
+sudo apt install nvidia-container-toolkit
+sudo nvidia-ctk runtime configure --runtime=docker
+sudo systemctl restart docker
+```
+
+That last step registers an `nvidia` runtime with the Docker daemon, which is what lets a `deploy.resources.reservations.devices` block in a compose file request GPU access.
+
+## Preserving Data (the Part I Was Most Careful About)
+
+This was the part I couldn't afford to get wrong: I did **not** want to re-download the model library, and I definitely didn't want to lose Open WebUI's existing chat history and user accounts.
+
+- For Ollama, I bind-mounted the real, existing data directory (`/usr/share/ollama/.ollama`) straight into the container, instead of letting it create a fresh one. (Worth noting: there was also a stale `/home/jacob/.ollama` on the box that was *not* the live store — the running service's models actually lived under the `ollama` user's home, so confirming the authoritative path first mattered.)
+- For Open WebUI, I reused its existing named Docker volume by declaring it `external: true` in the compose file, so compose adopts the volume that's already there rather than creating a new empty one.
+
+Both came up with everything intact — same models, same chats, same accounts, zero re-downloading.
+
+## Pinned Versions
+
+The original Open WebUI container was running `:main` — convenient for grabbing the newest features, bad for reproducibility, since the exact same command could pull a different image tomorrow. I pinned both images to specific version tags in the compose file so a `docker compose up` today and a `docker compose up` six months from now behave identically until I explicitly decide to bump a version.
+
+## Host Networking for Parity
+
+I kept both services on `network_mode: host`, matching the original setup. The main reason: Home Assistant's Ollama integration is already pointed at `127.0.0.1:11434`, and I didn't want to touch that config as part of what should otherwise be an invisible migration. Everything reaches the same addresses it always did.
+
+> **Note:** Host networking means both containers share the host's network namespace directly, which is a looser isolation boundary than a bridge network with explicit port mappings. It's on my list as a future improvement — swap to a dedicated Docker network with only the necessary ports published — but it wasn't worth doing at the same time as this migration.
+
+Here's a sanitized version of the resulting `docker-compose.yml`:
+
+```yaml
+services:
+  ollama:
+    image: ollama/ollama:0.30.10
+    container_name: ollama
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - OLLAMA_HOST=127.0.0.1:11434
+      - NVIDIA_VISIBLE_DEVICES=all
+      - NVIDIA_DRIVER_CAPABILITIES=compute,utility
+    volumes:
+      - /usr/share/ollama/.ollama:/root/.ollama
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+
+  open-webui:
+    image: ghcr.io/open-webui/open-webui:v0.9.6
+    container_name: open-webui
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - WEBUI_SECRET_KEY=${WEBUI_SECRET_KEY}
+      - ENABLE_SIGNUP=false
+      - OLLAMA_BASE_URL=http://127.0.0.1:11434
+    volumes:
+      - open-webui:/app/backend/data
+    depends_on:
+      - ollama
+
+volumes:
+  open-webui:
+    external: true
+```
+
+And the matching `.env.example` (the real `.env` never leaves the server):
+
+```bash
+# Copy to .env and fill in a real value — never commit the real .env
+WEBUI_SECRET_KEY=REPLACE_WITH_OPENSSL_RAND_HEX_32
+```
+
+> **Note:** `.env` is listed in `.gitignore` on the server and is never committed to any repo. Only `.env.example`, with placeholder values, is meant to be shared.
+
+## The Cutover
+
+The actual switch was anticlimactic, which is what you want from infrastructure work: I stopped and disabled the native Ollama systemd service (`sudo systemctl disable --now ollama`), double-checked the model directory was untouched, and brought the new stack up:
+
+```bash
+docker compose up -d
+```
+
+Open WebUI reconnected to Ollama immediately, the model list populated exactly as before, and Home Assistant's integration didn't even notice anything had changed. The family stack came back up cleanly, now managed with one command and one file instead of two different mental models.
+
+---
+
+[← Back to Home](../../README.md)

--- a/posts/2026-07-10-plex-into-docker/README.md
+++ b/posts/2026-07-10-plex-into-docker/README.md
@@ -1,0 +1,74 @@
+# Plex Joins the Stack: Containerizing a 1 TB Library Without Losing It
+
+**Date:** July 10, 2026  
+**Author:** Jacob Frericks  
+**Tags:** homelab, docker, plex, migration, gpu
+
+---
+
+In the last post I said Plex's migration "isn't unfinished so much as intentionally waiting for a human." This is me being that human. Plex was the last service still living outside the Compose stack — a native `.deb` install updating itself through `apt`, with a containerized replacement already written but deliberately gated off so it couldn't start by accident. Time to actually flip it.
+
+I picked the [LinuxServer.io](https://docs.linuxserver.io/images/docker-plex/) image (`lscr.io/linuxserver/plex`) for a few concrete reasons: its `PUID`/`PGID` convention maps cleanly onto my user's uid/gid `1000`, it has the best-documented NVIDIA hardware-transcode recipe (which reuses the Container Toolkit I'd already installed for Ollama, so the 3090 does NVENC for Plex and CUDA for inference), and its clean `1.43.2`-style tags play nicely with Dependabot.
+
+## The Surprise: Where the Media Actually Lived
+
+My first draft of the Plex service bind-mounted `/media` into the container. That turned out to be wrong in a way that would have quietly broken everything: `/media` was **empty**. My actual ~1 TB library (Movies and TV Shows) lived *inside* the native Plex data directory itself — `/var/lib/plexmediaserver/Library/Movies` and `/TVShows`. And critically, Plex's database records the absolute path of every file. If I'd started the container with the media somewhere new, Plex would have come up with every library showing as "unavailable."
+
+The clean fix was to stop trying to relocate anything and instead **bind-mount the media at its original absolute path**:
+
+```yaml
+volumes:
+  - /home/jacob/docker/plex/config:/config
+  - /var/lib/plexmediaserver/Library/Movies:/var/lib/plexmediaserver/Library/Movies
+  - /var/lib/plexmediaserver/Library/TVShows:/var/lib/plexmediaserver/Library/TVShows
+```
+
+Because the path inside the container is identical to the path the database recorded, every library entry resolves with zero re-matching — no "fix match," no re-scan, watch history intact.
+
+## The Empty-Init Trick
+
+The other thing I didn't want to guess at was *where* inside `/config` the container expects its database. Rather than assume, I started the container once against an **empty** config directory and looked at the skeleton it created:
+
+```
+/config/Library/Application Support/Plex Media Server/
+```
+
+So the LinuxServer image nests the data one level deeper than I'd have guessed. Knowing that for certain, I stopped the container, `rsync`'d the native `Plex Media Server` folder (the ~1.4 GB database and preferences — the media is separate) into exactly that path, and `chown`'d it to `1000:1000`.
+
+> **Note:** Discovering the layout empirically took about thirty seconds and saved me from a subtle failure where Plex starts with an empty database sitting next to my real one, ignored. When a path convention matters, it's worth letting the software tell you rather than trusting a forum post (including my own earlier notes, which had this detail wrong).
+
+## The Cutover
+
+With the data in place, the actual switch was small: stop, disable, and mask the native `plexmediaserver.service` so it couldn't grab port 32400, then bring up the container. Because I'd copied the original `Preferences.xml` wholesale, the server kept its identity — it came back **already claimed to my account**, no re-claim needed. A quick check confirmed the important things:
+
+- `/identity` reported `claimed="1"`.
+- Both libraries resolved: **189 movies, 21 TV shows**.
+- `/dev/nvidia0` and `/dev/dri/renderD129` were present inside the container, so hardware transcode works.
+
+## Removing the Native Install (Carefully)
+
+The final step was cleaning up the native package — and this is where the "keep the media where it is" constraint got interesting. My media now lived *inside* the native package's own data directory. So I read the package's removal script before running anything, and found this:
+
+```sh
+if [ "$1" = "purge" ]; then
+  ...
+  rm -rf /var/lib/plexmediaserver
+```
+
+That `rm -rf` — the one that would delete my entire library — only fires on **`purge`**. A plain `apt remove` leaves the data directory alone. So:
+
+```bash
+sudo apt-get remove plexmediaserver   # NOT --purge
+```
+
+removed the binaries and the systemd unit while leaving `Library/Movies` and `Library/TVShows` untouched. I then cleaned up two things the package's own script missed (its `postrm` has a typo that skips deleting the apt source, and my earlier `mask` left a dangling symlink), and reclaimed the 1.4 GB of now-redundant native database — the container has its own copy.
+
+> **Note:** `apt purge plexmediaserver` would delete the library. That's now written in a warning right next to the service definition in the Compose file, because the one-word difference between `remove` and `purge` is a 1 TB mistake.
+
+---
+
+The stack is now genuinely one Compose file — every service on the box, Plex included, described in one place, updated through the same pipeline. The lesson that kept recurring in this migration is that the safe path is almost always the boringly literal one: bind the media where it already is, ask the software where its files go, and read the uninstall script before you run it. Nothing here was clever — it was just careful, and for a family's 1 TB of movies, careful is exactly the right amount of clever.
+
+---
+
+[← Back to Home](../../README.md)

--- a/posts/2026-07-10-securing-the-server/README.md
+++ b/posts/2026-07-10-securing-the-server/README.md
@@ -1,0 +1,112 @@
+# Locking Down the Server: SSH, Firewall, and Secrets
+
+**Date:** July 10, 2026  
+**Author:** Jacob Frericks  
+**Tags:** homelab, security, ssh, firewall
+
+---
+
+The server has quietly graduated from "thing I tinker with on weekends" to "thing my family actually depends on" — Open WebUI, Home Assistant, and Plex are all real services now, used by real people every day. That's exactly the moment to stop and do a proper security audit, before I ever think about exposing anything to the outside world. I went through the box top to bottom and found several gaps worth closing.
+
+## SSH Hardening
+
+I was still SSHing in with a password, which is a habit from the "it's just a lab box" days that needed to go. First, I generated a dedicated ed25519 key just for this server:
+
+```bash
+ssh-keygen -t ed25519 -C "homeserver-access" -f ~/.ssh/homeserver_ed25519
+```
+
+Why a dedicated key instead of reusing one I already had? If it's ever compromised, or I want to revoke access from a device, I can kill this one key without touching access to anything else.
+
+I installed it with `ssh-copy-id`:
+
+```bash
+ssh-copy-id -i ~/.ssh/homeserver_ed25519.pub jacob@192.168.86.63
+```
+
+Then added an alias to `~/.ssh/config` so I don't have to remember an IP or a key path ever again:
+
+```
+Host homeserver
+    HostName 192.168.86.63
+    User jacob
+    IdentityFile ~/.ssh/homeserver_ed25519
+```
+
+Now it's just `ssh homeserver`. With the key confirmed working, I disabled password authentication entirely in `/etc/ssh/sshd_config`:
+
+```bash
+PasswordAuthentication no
+```
+
+```bash
+sudo systemctl restart ssh
+```
+
+> **Note:** Test the key-based login from a *second* terminal before you restart `ssh` or log out. If something's wrong with the key setup, you want a still-open session to fix it from, not a locked-out box.
+
+I verified password logins are now refused (`Permission denied (publickey)`), which is exactly what I wanted to see.
+
+---
+
+## A Stable IP Without a Static Config
+
+The server had been on DHCP this whole time, which meant its IP could theoretically shift on a lease renewal — annoying for an SSH alias, and a real problem the moment other services start pointing at it by IP. My instinct was to just set a static IP on the machine, but I went a different route: I reserved its address in the router instead.
+
+Since I'm running Google Wifi, this was done through the Google Home app: **Devices → the server → reserve IP**, binding the wired NIC's MAC address to `192.168.86.63`.
+
+Why reserve it at the router instead of hardcoding it on the box? The router is the single source of truth for the network either way — if I set a static IP on the machine *and* the router's DHCP pool didn't know to avoid it, I'd be one unlucky lease away from an IP conflict. Letting the router hand out the same address every time avoids that entirely, and the server's own network config stays simple.
+
+I rebooted the server to confirm it came back up with the same address, and it did.
+
+---
+
+## Firewall: From Nothing to Deny-by-Default
+
+This was the biggest gap. The server had **no firewall at all** — every port any service opened was reachable by anything on the LAN. Fine when it was just me experimenting; not fine now.
+
+I installed `ufw` and set a deny-by-default posture:
+
+```bash
+sudo apt install ufw
+sudo ufw default deny incoming
+sudo ufw default allow outgoing
+```
+
+Then I allowed only the ports actually in use on the LAN:
+
+```bash
+sudo ufw allow 22/tcp        # SSH
+sudo ufw allow 8080/tcp      # Open WebUI
+sudo ufw allow 8123/tcp      # Home Assistant
+sudo ufw allow 32400/tcp     # Plex
+sudo ufw allow 10200/tcp     # Wyoming voice (STT)
+sudo ufw allow 10300/tcp     # Wyoming voice (TTS)
+sudo ufw enable
+```
+
+> **Note:** Ollama's own port, `11434`, was deliberately **left closed**. Ollama ships with no authentication of any kind — anyone who can reach that port can run inference, pull models, and burn GPU time. It only needs to be reachable from `localhost` (Open WebUI and Home Assistant both talk to it via `127.0.0.1`), so there's no reason to open it on the LAN interface at all.
+
+---
+
+## Open WebUI Was Signing Sessions With an Empty Key
+
+While auditing the Open WebUI container config, I found something I should have caught on day one: `WEBUI_SECRET_KEY` was unset, meaning session tokens were being signed with an empty key. Not great for something that gates access to the whole family's chat history.
+
+I generated a proper random secret:
+
+```bash
+openssl rand -hex 32
+```
+
+and set it as `WEBUI_SECRET_KEY` in the container's environment, along with disabling open signups so the login page can't be used to self-register a new account.
+
+> **Note:** The real secret lives in a server-local `.env` file, never committed to git. Anything in this post referencing it is a placeholder.
+
+---
+
+Remote access — reaching any of this from outside the house — is still completely off, and it's going to stay that way until it goes through a self-hosted WireGuard VPN. I have no intention of ever exposing Open WebUI, Home Assistant, or Plex directly to the internet; a VPN means the attack surface stays exactly one endpoint, one that I control.
+
+---
+
+[← Back to Home](../../README.md)

--- a/posts/2026-07-10-whole-stack-in-git/README.md
+++ b/posts/2026-07-10-whole-stack-in-git/README.md
@@ -1,0 +1,63 @@
+# Bringing the Whole Stack Under One Roof: Dependabot, CI, and Containerizing Plex
+
+**Date:** July 10, 2026  
+**Author:** Jacob Frericks  
+**Tags:** homelab, docker, compose, dependabot, ci-cd, plex, home-assistant
+
+---
+
+In the last post I said the container-update story was "the next piece of that puzzle, once there's a proper pipeline to make it safe." This is that piece.
+
+The compose migration got Ollama and Open WebUI into one declarative file — but that was only half the box. Home Assistant, Piper (Wyoming TTS), and Whisper (Wyoming STT) were still three hand-run `docker run` containers I'd started once and forgotten, and Plex was a native `.deb` systemd service updating itself through `apt`. So I was right back to the asymmetry I'd just spent a post complaining about, only with more moving parts. The goal here: **one compose file, in git, with automated-but-safe updates for the entire stack.**
+
+## Step Zero: Pin the Moving Tags
+
+The three stray containers were all running moving tags — Home Assistant on `:stable`, Piper and Whisper on `:latest`. Those are convenient and completely opaque: the same tag can point at a different image tomorrow, and there's nothing for an update tool to bump *toward*.
+
+Dependabot's docker ecosystem only opens a meaningful PR when it can compare a concrete version against a newer concrete version, so the first move was to resolve each running image to its actual published version and pin it — the same thing I'd already done for Ollama and Open WebUI:
+
+| Service | Was | Pinned to |
+|---|---|---|
+| homeassistant | `:stable` | `ghcr.io/home-assistant/home-assistant:2026.2.1` |
+| piper | `:latest` | `rhasspy/wyoming-piper:2.2.2` |
+| whisper | `:latest` | `rhasspy/wyoming-whisper:3.1.0` |
+
+For the two on `:latest`, I matched the running container's image digest against Docker Hub's published tags to find which concrete version it actually was, so the first `compose up` recreated a byte-equivalent image instead of silently pulling something newer.
+
+## Folding In Home Assistant and Wyoming
+
+Once pinned, these three were a straight translation from `docker run` flags to compose service blocks. The reassuring part is that **all of their state lives in host bind mounts** — Home Assistant's `/config`, Whisper's model cache — so the cutover was genuinely risk-free: stop and remove the old standalone container, and `docker compose up -d` recreates it pointed at the exact same directory on disk. Nothing to migrate, nothing to lose.
+
+Home Assistant keeps `network_mode: host` and `privileged: true` (it needs both for device discovery and its supervisor-style access), Piper and Whisper stay on the bridge network with their `10200`/`10300` ports published, and HA's Assist voice pipeline reached both of them again on the first boot without any config change.
+
+After the cutover, `docker compose ps` showed five services under one project and **zero stray standalone containers left** — exactly the state I wanted.
+
+## The Update Policy: Automatic, but Not Reckless
+
+This is the part that makes automation safe enough to actually turn on. Dependabot watches every `image:` tag in the compose file and opens a PR per available bump; a CI workflow validates each one (`docker compose config` to catch a broken file, `yamllint`, and a `gitleaks` scan so a real secret can never sneak into what's meant to be a public repo). Then an auto-merge workflow applies a deliberately conservative rule:
+
+- **Patch and minor bumps auto-merge** once CI is green — these are the routine "features and fixes" updates.
+- **Every major bump stays open for me to review** — including Ollama, where a major version is the most likely thing to disturb inference.
+- **Home Assistant is always manual, regardless of bump size.** HA uses calendar versioning, and its monthly "minor" releases routinely carry documented breaking changes. Treating an HA `2026.2 → 2026.3` as a safe minor would be exactly the kind of "broken service on a random Tuesday" I'm trying to avoid.
+
+That maps cleanly onto the rule I set for myself earlier: automate the things with a well-understood, low-risk blast radius, and keep a human in the loop for anything that could quietly break the family's smart home or the AI stack.
+
+## Containerizing Plex (the Deliberate, Not-Yet-Pulled Trigger)
+
+Plex was the odd one out — a native `.deb` service, not a container at all. Since it isn't in active use right now, I chose the higher-effort-but-cleaner long-term path: bring it into the compose stack too, using the LinuxServer.io image (`lscr.io/linuxserver/plex`). That image was the right call for a few concrete reasons:
+
+- Its `PUID`/`PGID` convention maps straight onto my user's uid/gid `1000`, so the config files stay owned by me.
+- It has the best-documented NVIDIA hardware-transcode recipe, which reuses the same Container Toolkit I already installed for Ollama — the 3090 does NVENC for Plex and CUDA for inference (light-load contention between the two is fine).
+- Its clean `1.43.2`-style semver tags classify correctly under the patch/minor auto-merge rule, unlike the official image's build-hash tags.
+
+The important honesty here: **the Plex service is authored and validated, but not started.** The native install still owns `:32400` and its ~1 TB library, and moving that data needs interactive `sudo` on the console — not something I'd run blind over SSH at 4 AM. So the container is gated behind a compose `profiles: ["plex-cutover"]` flag, which means the weekly deploy's plain `docker compose up -d` **never** starts it and races the native service for the port. It sits dormant until I explicitly run the cutover, and the full runbook (stop/disable/mask the native service, `rsync` + `chown` the library, bring the container up, verify, and a rollback path that just un-masks the native service) is written down in the infra repo for when I'm ready.
+
+> **Note:** Gating a defined-but-dangerous service behind a compose profile turned out to be the quiet hero of this change. It let me commit the *whole* target state to git today without the automation acting on the one piece that still needs my hands on it.
+
+---
+
+The through-line across these last few posts is the same one every time: consolidate everything into one declarative source of truth, then automate only the parts whose failure I can shrug off. This change extended that from "the two AI services" to "essentially the entire box" — and the one exception, Plex's data migration, isn't unfinished so much as *intentionally waiting for a human*, which is its own kind of done.
+
+---
+
+[← Back to Home](../../README.md)


### PR DESCRIPTION
Adds the July 2026 batch of journey posts documenting the security + Compose overhaul of the home server:

1. **Locking Down the Server** — SSH hardening, reserved IP, UFW, fixing the empty Open WebUI secret key.
2. **Consolidating the AI Stack with Docker Compose** — Ollama + Open WebUI into one declarative stack (GPU passthrough, data preservation).
3. **Automating OS Updates** — unattended-upgrades for security patches while holding the GPU stack.
4. **Bringing the Whole Stack Under One Roof** — pinning the last hand-run containers, folding HA + Wyoming into Compose, the Dependabot auto-merge policy, and staging Plex behind a profile gate.
5. **Plex Joins the Stack** — migrating Plex from the native `.deb` into Compose: binding media at its original paths, the empty-init config-layout discovery, and removing the native package without a data-deleting `purge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)